### PR TITLE
Parameterize URI base for graph name

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ To build (requires Java 8):
     cd trippi-sparql ; mvn clean install
 
 This will result in a large `trippi-sparql-*.jar` JAR in the `trippi-sparql/trippi-sparql/target/` directory which contains the connector and its dependencies, and a `trippi-sparql-fcrepo-webapp-*.war` WAR in `trippi-sparql/trippi-sparql-fcrepo-webapp/target` . To use this connector with Fedora 3, this large JAR can be dropped into the `WEB-INF/lib/` directory of a Fedora 3 web-application, or the WAR file can be used (it is simply the ordinary Fedora 3 web-application with the JAR pre-installed). Then, a `<datastore/>` element must be configured in `fedora.fcfg`. An example is shown below featuring the various parameters available. For each parameter except `connectorClassName` and `updateEndpoint`, a default will be used if no `<param/>` element for that parameter is supplied. The default value for each parameter will be the value shown in the example below, except that the default for the SPARQL CONSTRUCT Query endpoint is just the ordinary SPARQL Query endpoint, and the default for the ordinary SPARQL Query endpoint is the SPARQL Update endpoint.
-The default for `graphName` is as shown, but users should be aware that any relative URI used there (the default `#ri` is as used by Fedora 3's Mulgara configuration) will be resolved against a static base URI stored in the constant `edu.si.trippi.impl.sparql.SparqlConnector.BASE_URI`. Queries transmitted through Fedora's Resource Index API will be automatically  equipped with an appropriate BASE declaration, but otherwise, clients are responsible for ensuring that the base URI is used correctly. A convenience method `SparqlConnector::rebase` is available for the purpose.
+The default for `graphName` is as shown, but users should be aware that any relative URI used there (the default `#ri` is as used by Fedora 3's Mulgara configuration) will be resolved against a base URI configured in the parameter `uriBase` with default as shown below. Queries transmitted through Fedora's Resource Index API will be automatically  equipped with an appropriate BASE declaration, but otherwise, clients that use the SPARQL endpoints directly are responsible for ensuring that the base URI is used correctly. A convenience method `SparqlConnector::rebase` is available for the purpose.
 
 
     <datastore id="sparqlTriplestore">
@@ -18,6 +18,9 @@ The default for `graphName` is as shown, but users should be aware that any rela
         </param>
         <param name="graphName" value="#ri">
             <comment>The URI of the named graph in which triples will be managed.</comment>
+        </param>
+        <param name="uriBase" value="info:edu.si.fedora">
+            <comment>The base that will be used to resolve a graph name that is a relative URI.</comment>
         </param>
         <param name="maxHttpConnections" value="10">
             <comment>The maximum number of clients in the HTTP client pool used for SPARQL Update requests.</comment>

--- a/trippi-sparql/src/main/java/edu/si/trippi/impl/sparql/SparqlConnector.java
+++ b/trippi-sparql/src/main/java/edu/si/trippi/impl/sparql/SparqlConnector.java
@@ -65,7 +65,9 @@ public class SparqlConnector extends TriplestoreConnector {
 
     private static final Logger log = getLogger(SparqlConnector.class);
 
-    public static final String BASE_URI = "info:edu.si.fedora";
+    public static String DEFAULT_URI_BASE = "info:edu.si.fedora";
+
+    public static String uriBase;
 
     /**
      * In order to resolve relative URIs in a repeatable way, this method should always be used to provide a BASE_URI
@@ -75,7 +77,7 @@ public class SparqlConnector extends TriplestoreConnector {
      * @return the same test with a BASE_URI declaration prefixed
      */
     public static String rebase(final String text) {
-        return format("BASE <" + BASE_URI + ">\n%1$s", text);
+        return format("BASE <" + uriBase + ">\n%1$s", text);
     }
 
     public static final String DEFAULT_BUFFER_FLUSH_BATCH_SIZE = "20000";
@@ -166,6 +168,8 @@ public class SparqlConnector extends TriplestoreConnector {
         log.info("Using construct endpoint {}", constructEndpoint);
         final Node graphName = createURI(config.getOrDefault("graphName", "#ri"));
         log.info("Using graph name {}", stringForNode(graphName));
+        final String uriBase = config.getOrDefault("uriBase", DEFAULT_URI_BASE);
+        log.info("Using URI base {}", uriBase);
 
         if (factory != null) {
             factory.close();


### PR DESCRIPTION
Allows the base used to resolve a relative graph name to be configured.